### PR TITLE
Update framer-motion to v11.0.6 from v6.3.3 fixing post state update on feed type change

### DIFF
--- a/components/Feed.tsx
+++ b/components/Feed.tsx
@@ -33,7 +33,6 @@ export default function Feed({ type }) {
     // refreshInterval: 30000,
     revalidateOnFocus: false,
     revalidateOnReconnect: true,
-    refreshWhenOffline: true,
   });
 
   const [modalOpen, setModalOpen] = useState(false);
@@ -97,13 +96,13 @@ export default function Feed({ type }) {
     }
     if (operation === "reply") {
       mutate({
-        posts: data?.posts.map((post: any) => {
-          if (post._id === id) {
-            post.comments?.push(newPost);
-          }
-          return post;
-        }),
-      },
+          posts: data?.posts.map((post: any) => {
+            if (post._id === id) {
+              post.comments?.push(newPost);
+            }
+            return post;
+          }),
+        },
         {
           revalidate: false,
           rollbackOnError: true,
@@ -185,33 +184,33 @@ export default function Feed({ type }) {
 
         <AnimatePresence>
           {data?.posts
-                ?.slice(0, 40)
-                .sort(
-                  (
-                    a: { createdAt: string | number | Date },
-                    b: { createdAt: string | number | Date }
-                  ) => {
-                    const dateA = new Date(a.createdAt) as any;
-                    const dateB = new Date(b.createdAt) as any;
-                    return dateB - dateA; // Sort in descending order
-                  }
-                )
-                .map((post: { _id: Key | null | undefined }) => (
-                  <motion.div
-                    key={post._id}
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    exit={{ opacity: 0 }}
-                    transition={{ duration: 1 }}
-                  >
-                    <Post
-                      key={post?._id}
-                      id={post?._id}
-                      post={post}
-                      updatePosts={updatePosts}
-                    />
-                  </motion.div>
-                ))}
+            ?.slice(0, 40)
+            .sort(
+              (
+                a: { createdAt: string | number | Date },
+                b: { createdAt: string | number | Date }
+              ) => {
+                const dateA = new Date(a.createdAt) as any;
+                const dateB = new Date(b.createdAt) as any;
+                return dateB - dateA; // Sort in descending order
+              }
+            )
+            .map((post: { _id: Key | null | undefined }) => (
+              <motion.div
+                key={post._id}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 1 }}
+              >
+                <Post
+                  key={post?._id}
+                  id={post?._id}
+                  post={post}
+                  updatePosts={updatePosts}
+                />
+              </motion.div>
+            ))}
         </AnimatePresence>
 
         {modalOpen && (

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@heroicons/react": "^2.0.18",
         "@react-google-maps/api": "^2.19.2",
         "axios": "^1.5.0",
-        "framer-motion": "^6.3.3",
+        "framer-motion": "11.0.6",
         "jose": "^4.14.6",
         "jsonwebtoken": "^9.0.2",
         "moment": "^2.29.3",
@@ -66,9 +66,9 @@
       }
     },
     "node_modules/@adobe/css-tools": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
-      "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.3.tgz",
+      "integrity": "sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==",
       "dev": true
     },
     "node_modules/@alloc/quick-lru": {
@@ -1443,64 +1443,6 @@
       "optional": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
-      }
-    },
-    "node_modules/@motionone/animation": {
-      "version": "10.16.3",
-      "resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.16.3.tgz",
-      "integrity": "sha512-QUGWpLbMFLhyqKlngjZhjtxM8IqiJQjLK0DF+XOF6od9nhSvlaeEpOY/UMCRVcZn/9Tr2rZO22EkuCIjYdI74g==",
-      "dependencies": {
-        "@motionone/easing": "^10.16.3",
-        "@motionone/types": "^10.16.3",
-        "@motionone/utils": "^10.16.3",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/dom": {
-      "version": "10.12.0",
-      "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.12.0.tgz",
-      "integrity": "sha512-UdPTtLMAktHiqV0atOczNYyDd/d8Cf5fFsd1tua03PqTwwCe/6lwhLSQ8a7TbnQ5SN0gm44N1slBfj+ORIhrqw==",
-      "dependencies": {
-        "@motionone/animation": "^10.12.0",
-        "@motionone/generators": "^10.12.0",
-        "@motionone/types": "^10.12.0",
-        "@motionone/utils": "^10.12.0",
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/easing": {
-      "version": "10.16.3",
-      "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.16.3.tgz",
-      "integrity": "sha512-HWTMZbTmZojzwEuKT/xCdvoMPXjYSyQvuVM6jmM0yoGU6BWzsmYMeB4bn38UFf618fJCNtP9XeC/zxtKWfbr0w==",
-      "dependencies": {
-        "@motionone/utils": "^10.16.3",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/generators": {
-      "version": "10.16.4",
-      "resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.16.4.tgz",
-      "integrity": "sha512-geFZ3w0Rm0ZXXpctWsSf3REGywmLLujEjxPYpBR0j+ymYwof0xbV6S5kGqqsDKgyWKVWpUInqQYvQfL6fRbXeg==",
-      "dependencies": {
-        "@motionone/types": "^10.16.3",
-        "@motionone/utils": "^10.16.3",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/types": {
-      "version": "10.16.3",
-      "resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.16.3.tgz",
-      "integrity": "sha512-W4jkEGFifDq73DlaZs3HUfamV2t1wM35zN/zX7Q79LfZ2sc6C0R1baUHZmqc/K5F3vSw3PavgQ6HyHLd/MXcWg=="
-    },
-    "node_modules/@motionone/utils": {
-      "version": "10.16.3",
-      "resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.16.3.tgz",
-      "integrity": "sha512-WNWDksJIxQkaI9p9Z9z0+K27xdqISGNFy1SsWVGaiedTHq0iaT6iZujby8fT/ZnZxj1EOaxJtSfUPCFNU5CRoA==",
-      "dependencies": {
-        "@motionone/types": "^10.16.3",
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.3.1"
       }
     },
     "node_modules/@mswjs/cookies": {
@@ -4824,9 +4766,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",
@@ -4890,31 +4832,26 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.5.1.tgz",
-      "integrity": "sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==",
+      "version": "11.0.6",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.0.6.tgz",
+      "integrity": "sha512-BpO3mWF8UwxzO3Ca5AmSkrg14QYTeJa9vKgoLOoBdBdTPj0e81i1dMwnX6EQJXRieUx20uiDBXq8bA6y7N6b8Q==",
       "dependencies": {
-        "@motionone/dom": "10.12.0",
-        "framesync": "6.0.1",
-        "hey-listen": "^1.0.8",
-        "popmotion": "11.0.3",
-        "style-value-types": "5.0.0",
-        "tslib": "^2.1.0"
+        "tslib": "^2.4.0"
       },
       "optionalDependencies": {
         "@emotion/is-prop-valid": "^0.8.2"
       },
       "peerDependencies": {
-        "react": ">=16.8 || ^17.0.0 || ^18.0.0",
-        "react-dom": ">=16.8 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/framesync": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
-      "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
-      "dependencies": {
-        "tslib": "^2.1.0"
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/fs-constants": {
@@ -5284,11 +5221,6 @@
       "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
       "dev": true
     },
-    "node_modules/hey-listen": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
-      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
-    },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
@@ -5519,9 +5451,9 @@
       }
     },
     "node_modules/ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
     },
     "node_modules/is-arguments": {
       "version": "1.1.1",
@@ -8349,17 +8281,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/popmotion": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
-      "integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
-      "dependencies": {
-        "framesync": "6.0.1",
-        "hey-listen": "^1.0.8",
-        "style-value-types": "5.0.0",
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -9606,15 +9527,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/style-value-types": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
-      "integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
-      "dependencies": {
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/styled-jsx": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.2.tgz",
@@ -10214,9 +10126,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.0.tgz",
-      "integrity": "sha512-gM12DkXhlAc5+/TPe60iy9P6ETgVfqTuRJ6aQ4w8RYu0MqKuXhaq3/b86GfzDQnNA3NUO6aUNdvevrKH59D0Nw==",
+      "version": "5.28.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
+      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
       "dev": true,
       "dependencies": {
         "@fastify/busboy": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@heroicons/react": "^2.0.18",
     "@react-google-maps/api": "^2.19.2",
     "axios": "^1.5.0",
-    "framer-motion": "^6.3.3",
+    "framer-motion": "11.0.6",
     "jose": "^4.14.6",
     "jsonwebtoken": "^9.0.2",
     "moment": "^2.29.3",


### PR DESCRIPTION
This pull request focuses on updating the framer-motion library from version **`6.3.3`** to **`11.0.6`**. The primary motivation for this update was to resolve an issue with the `<AnimatedPresence>` component. Previously, even after updating the posts array, the component caused old posts to remain displayed but hidden, occupying space with an opacity of `0`. This behaviour was due to a bug in the library itself. By upgrading to version `11.0.6`, we address this issue directly, ensuring that the post state is properly updated when changing the feed type, and posts display as expected without lingering hidden elements.